### PR TITLE
Migrate to spack package api v2.0. Add wire-cell-toolkit versions and checksums

### DIFF
--- a/spack-repo-index.yaml
+++ b/spack-repo-index.yaml
@@ -1,0 +1,3 @@
+repo_index:
+  paths:
+  - spack_repo/wirecell

--- a/spack_repo/wirecell/packages/go_jsonnet/package.py
+++ b/spack_repo/wirecell/packages/go_jsonnet/package.py
@@ -22,6 +22,7 @@
 
 from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
+from spack_repo.builtin.build_systems.python import PythonExtension, PythonPipBuilder
 
 
 class GoJsonnet(Package):
@@ -71,7 +72,8 @@ class GoJsonnet(Package):
     @run_after("install")
     def python_install(self):
         if "+python" in self.spec:
-            args = list(std_pip_args)
+            pip_args = PythonPipBuilder.std_args(self)
+            args = list(pip_args)
             args.append("--prefix=" + self.prefix)
             args.append(".")
             pip(*args)

--- a/spack_repo/wirecell/packages/go_jsonnet/package.py
+++ b/spack_repo/wirecell/packages/go_jsonnet/package.py
@@ -20,6 +20,7 @@
 # See the Spack documentation for more information on packaging.
 # ----------------------------------------------------------------------------
 
+from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/jsonnet/package.py
+++ b/spack_repo/wirecell/packages/jsonnet/package.py
@@ -5,10 +5,11 @@
 
 
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
+from spack_repo.builtin.build_systems.python import PythonExtension, PythonPipBuilder
 from spack.package import *
 
 
-class Jsonnet(MakefilePackage):
+class Jsonnet(MakefilePackage, PythonExtension):
     """A data templating language for app and tool developers based on JSON"""
 
     homepage = "https://jsonnet.org/"
@@ -38,5 +39,6 @@ class Jsonnet(MakefilePackage):
     @run_after("install")
     def python_install(self):
         if "+python" in self.spec:
-            args = std_pip_args + ["--prefix=" + self.prefix, "."]
+            pip_args = PythonPipBuilder.std_args(self)
+            args = list(pip_args) + ["--prefix=" + self.prefix, "."]
             pip(*args)

--- a/spack_repo/wirecell/packages/jsonnet/package.py
+++ b/spack_repo/wirecell/packages/jsonnet/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack_repo.builtin.build_systems.makefile import MakefilePackage
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/ollamabin/package.py
+++ b/spack_repo/wirecell/packages/ollamabin/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/ollamalux/package.py
+++ b/spack_repo/wirecell/packages/ollamalux/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 class Ollamalux(Package):

--- a/spack_repo/wirecell/packages/paal/package.py
+++ b/spack_repo/wirecell/packages/paal/package.py
@@ -1,5 +1,5 @@
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
+#from spack.pkg.builtin.boost import Boost
 
 class Paal(Package):
     """
@@ -25,7 +25,6 @@ class Paal(Package):
     maintainers = ["bv@bnl.gov"]  # for this file, not paal
     # there are neither branches nor tags or other version identifiers.
     version("2017-01-30",
-            sha256="83487de59e8f7ded1a488ad8ad5359c358fb45a59e548d499f6dc44d712c82ad",
             commit="e537b58d50e93d4a72709821b9ea413008970c6b")
     version("master", branch="master")
 
@@ -33,7 +32,7 @@ class Paal(Package):
             description='PAAL is mainly a header only library. '
             'If you use linear programming you must link your executable against glpk.')
 
-    depends_on(Boost.with_default_variants)
+    depends_on('boost')
     depends_on('glpk', when='+glpk')
 
     def install(self, spec, prefix):

--- a/spack_repo/wirecell/packages/paal/package.py
+++ b/spack_repo/wirecell/packages/paal/package.py
@@ -1,5 +1,6 @@
 from spack.package import *
 #from spack.pkg.builtin.boost import Boost
+from spack_repo.builtin.build_systems.generic import Package
 
 class Paal(Package):
     """

--- a/spack_repo/wirecell/packages/py_wirecell/package.py
+++ b/spack_repo/wirecell/packages/py_wirecell/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.python import PythonPackage
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/snakemake/package.py
+++ b/spack_repo/wirecell/packages/snakemake/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.python import PythonPackage
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/wire_cell_data/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_data/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/wire_cell_dependencies/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_dependencies/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.bundle import BundlePackage
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/wire_cell_extra/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_extra/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.bundle import BundlePackage
 from spack.package import *
 
 

--- a/spack_repo/wirecell/packages/wire_cell_prototype/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_prototype/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.generic import Package
 from spack.package import *
 
 class WireCellPrototype(Package):

--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack_repo.builtin.build_systems.generic import Package
+from spack_repo.builtin.build_systems.generic import CudaPackage
 
 class WireCellToolkit(Package, CudaPackage):
     """Toolkit for Liquid Argon TPC Reconstruction and Visualization ."""

--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -5,7 +5,7 @@
 
 from spack.package import *
 from spack_repo.builtin.build_systems.generic import Package
-from spack_repo.builtin.build_systems.generic import CudaPackage
+from spack_repo.builtin.build_systems.cuda import CudaPackage
 
 class WireCellToolkit(Package, CudaPackage):
     """Toolkit for Liquid Argon TPC Reconstruction and Visualization ."""

--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -18,6 +18,16 @@ class WireCellToolkit(Package, CudaPackage):
     maintainers = ['brettviren']
 
     version("master", branch="master")
+    version("0.30.5", sha256="f665adf8e75af2ea26176acdae56816db6c1af2ecc86c405c49ab43c6a25e0b2")
+    version("0.30.4", sha256="5971364fb1a9b4c52abaeb563c8cc8742c912d6c7c57948de0cb76acd202127b")
+    version("0.30.3", sha256="cc95044a9de15cab33992084de94e07716a5c14cf2d3486b993c6ef6bad57027")
+    version("0.30.2", sha256="51cf692a9687e3124439ce824597c47e8dea38d7178161e3717602c330d74dc2")
+    version("0.30.1", sha256="cefef542978a1a10360e0b90532cde72a67763c2d2d3e8e1b39873ea61b36f45")
+    version("0.30.0", sha256="e5a5860145a821ce11d3040d71f7fb2bbfd3776820cd3808fd0cbaf33b401700")
+    version("0.29.5", sha256="2a16ae4b4e69bb570d79881f32ceb4868d2a9a16699419dd097765d45da06d03")
+    version("0.29.4", sha256="b2dcadc73b0945adbedf8fcaa0c81e0d0c400314514ae399a79b97e45d149415")
+    version("0.29.3", sha256="c8c9319cd5abe72db5bb9d5799b5463af3e996a551e17db10fd56281a36e7387")
+    version("0.29.2", sha256="7ca719da56d89dbe9ebcbb5755bbce99719a8cababb99aea8e24502f27c95e25")
     version("0.28.0", sha256="62f07ad8bf726ef8aaec428a84cae0ca61ca7b33d5c58f35d2c056f342fdc22c")
     version("0.27.1", sha256="a8410a9e0524570e811f5cca2ea9fc636e48c048a5e67c5cee567b935515e176")
     version("0.27.0", sha256="c4d1dc438b685bc54004425922f9435d8cb7f928a6b080b910cff021392571b2")
@@ -69,6 +79,10 @@ class WireCellToolkit(Package, CudaPackage):
             description='Add support for CUDA')
     variant('emacs', default=False,
             description='Add support for Emacs for documentation building')
+
+    # new requirements for compilers-as-nodes
+    depends_on('c', type=('build',))
+    depends_on('cxx', type=('build',))
 
     # just for build time (for waf/wcb)
     depends_on('python', type=('build',)) 

--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -168,6 +168,10 @@ class WireCellToolkit(Package, CudaPackage):
     # TODO: cuda, torch, zmq
 
     # ----------
+    #add version.txt needed when not doing git checkout
+    def patch(self):
+        with open("version.txt", "w") as version_file:
+            version_file.write(f"{self.version}\n")
 
     def install(self, spec, prefix):
 

--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -148,7 +148,7 @@ class WireCellToolkit(Package, CudaPackage):
 
     # Suggested:
 
-    depends_on('intel-tbb @2021.7.0: cxxstd=17', when='+tbb')
+    depends_on('tbb', when='+tbb')
 
 
     # Optional:

--- a/spack_repo/wirecell/repo.yaml
+++ b/spack_repo/wirecell/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: wirecell
+  api: v2.0


### PR DESCRIPTION
@brettviren I want to make use of the official wire-cell-toolkit package for building with Spack v1.0.
This is the initial migration of the packages.py to the spack package api v2.0 needed for Spack v1.0. 
Wire-cell-toolkit needed the dependency on c and cxx the compiler virtuals added for compilers as nodes in Spack v1.0.
It's probably safest to make a new Spack1.0 and merge in this pull request.
