### PR TITLE
wire-cell-toolkit: Add --with-root= when variant +root used, add --with-triton when triton in spec.

### DIFF
--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -253,6 +253,10 @@ class WireCellToolkit(Package, CudaPackage):
         if 'root' in spec:
             cfg += ['--with-root=' + spec['root'].prefix ]
 
+        if 'triton' in spec:
+            cfg += ['--with-triton=' + spec['triton'].prefix ]
+            cfg += ['--with-grpc=' + spec['grpc'].prefix ]
+
         # one or the other assured by +/~cppjsonnet?
         if 'jsonnet' in spec:
             jsonnet = 'jsonnet'

--- a/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
+++ b/spack_repo/wirecell/packages/wire_cell_toolkit/package.py
@@ -12,7 +12,6 @@ import os
 class WireCellToolkit(Package, CudaPackage):
     """Toolkit for Liquid Argon TPC Reconstruction and Visualization ."""
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://wirecell.github.io/"
     url      = "https://github.com/WireCell/wire-cell-toolkit/archive/refs/tags/0.23.0.tar.gz"
     git      = "https://github.com/WireCell/wire-cell-toolkit.git"
@@ -250,6 +249,9 @@ class WireCellToolkit(Package, CudaPackage):
 
         if 'tbb' in spec:
             cfg += ['--with-tbb=' + spec['tbb'].prefix ]
+
+        if 'root' in spec:
+            cfg += ['--with-root=' + spec['root'].prefix ]
 
         # one or the other assured by +/~cppjsonnet?
         if 'jsonnet' in spec:


### PR DESCRIPTION
@brettviren I found that the WireCellRoot module was not built by default. When I added the +root variant it still was not built. This PR adds the `--with-root=root-install-path` cfg option.